### PR TITLE
SC-34602 SC-34607 Allow to skip dry-run and to skip shadow2 run if not defined

### DIFF
--- a/run-iris/README.md
+++ b/run-iris/README.md
@@ -49,6 +49,18 @@ jobs:
           organization: "your-organization" # Optional: Organization name
 ```
 
+### Public mirror project issues sync
+
+```yaml
+- name: Sync public mirror project with IRIS
+  uses: SonarSource/unified-dogfooding-actions/run-iris@v1
+  with:
+    primary_project_key: "SonarSource_your-project-name-enterprise"
+    primary_platform: "Next" # Platform of the private project
+    shadow1_project_key: "SonarSource_your-project-name"
+    shadow1_platform: "Next" # Platform of the public mirror, can be the same as the primary platform
+```
+
 ### Complete Workflow Example
 
 ```yaml
@@ -63,16 +75,16 @@ permissions:
 
 on:
   schedule:
-    - cron: '20 */12 * * *'
+    - cron: "20 */12 * * *"
   workflow_dispatch:
     inputs:
       github_environment:
-        description: 'GitHub Environment'
+        description: "GitHub Environment"
         required: false
         type: string
         default: "ManualDispatch"
       runner_label:
-        description: 'GitHub Action runner'
+        description: "GitHub Action runner"
         required: false
         type: string
         default: "ubuntu-latest"
@@ -98,14 +110,14 @@ jobs:
 
 ### Required Inputs
 
-| Input | Description | Required | Default |
-|-------|-------------|----------|---------|
-| `primary_project_key` | Project key of the primary platform | Yes | - |
-| `primary_platform` | Platform of the primary platform (Next, SQC-EU, SQC-US) | Yes | - |
-| `shadow1_project_key` | Project key of the first shadow platform | Yes | - |
-| `shadow1_platform` | Platform of the first shadow platform (Next, SQC-EU, SQC-US) | Yes | - |
-| `shadow2_project_key` | Project key of the second shadow platform | Yes | - |
-| `shadow2_platform` | Platform of the second shadow platform (Next, SQC-EU, SQC-US) | Yes | - |
+| Input                 | Description                                                                                        | Required | Default |
+| --------------------- | -------------------------------------------------------------------------------------------------- | -------- | ------- |
+| `primary_project_key` | Project key of the primary platform                                                                | Yes      | -       |
+| `primary_platform`    | Platform of the primary platform (Next, SQC-EU, SQC-US)                                            | Yes      | -       |
+| `shadow1_project_key` | Project key of the first shadow platform                                                           | Yes      | -       |
+| `shadow1_platform`    | Platform of the first shadow platform (Next, SQC-EU, SQC-US)                                       | Yes      | -       |
+| `shadow2_project_key` | Project key of the second shadow platform, iris run is skipped if not provided                     | No       | -       |
+| `shadow2_platform`    | Platform of the second shadow platform (Next, SQC-EU, SQC-US), iris run is skipped if not provided | No       | -       |
 
 ### Optional Inputs
 
@@ -125,8 +137,8 @@ The workflow using this action must have the following permissions:
 
 ```yaml
 permissions:
-  id-token: write    # Required for vault authentication
-  contents: read     # Required for checkout
+  id-token: write # Required for vault authentication
+  contents: read # Required for checkout
 ```
 
 ### Required Secrets

--- a/run-iris/README.md
+++ b/run-iris/README.md
@@ -49,6 +49,22 @@ jobs:
           organization: "your-organization" # Optional: Organization name
 ```
 
+### Usage with startdate
+
+```yaml
+- name: Run IRIS Analysis
+  uses: SonarSource/unified-dogfooding-actions/run-iris@v1
+  with:
+    primary_project_key: "SonarSource_your-project-name"
+    primary_platform: "Next" # Platform of the primary platform (Next, SQC-EU, SQC-US)
+    shadow1_project_key: "SonarSource_your-project-name"
+    shadow1_platform: "SQC-EU" # Platform of the first shadow platform (Next, SQC-EU, SQC-US)
+    shadow2_project_key: "SonarSource_your-project-name"
+    shadow2_platform: "SQC-US" # Platform of the second shadow platform (Next, SQC-EU, SQC-US)
+    startdate: "2015-10-01" # Batch issues fetching month by month starting from this date
+    skip_dry_run: "true" # Optional: Skip dry run and perform actual changes directly
+```
+
 ### Public mirror project issues sync
 
 ```yaml
@@ -121,13 +137,15 @@ jobs:
 
 ### Optional Inputs
 
-| Input | Description | Required | Default |
-|-------|-------------|----------|---------|
-| `github_environment` | GitHub Environment | No | `ManualDispatch` |
-| `organization` | Organization name | No | `sonarsource` |
-| `sonar_sqc_eu_url` | SonarCloud EU URL | No | `https://sonarcloud.io` |
-| `sonar_sqc_us_url` | SonarCloud US URL | No | `https://sonarqube.us` |
-| `sonar_next_url` | SonarQube Next URL | No | `https://next.sonarqube.com/sonarqube` |
+| Input                | Description                                                                                                                 | Required | Default                                |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------------- | -------- | -------------------------------------- |
+| `github_environment` | GitHub Environment                                                                                                          | No       | `ManualDispatch`                       |
+| `organization`       | Organization name                                                                                                           | No       | `sonarsource`                          |
+| `sonar_sqc_eu_url`   | SonarCloud EU URL                                                                                                           | No       | `https://sonarcloud.io`                |
+| `sonar_sqc_us_url`   | SonarCloud US URL                                                                                                           | No       | `https://sonarqube.us`                 |
+| `sonar_next_url`     | SonarQube Next URL                                                                                                          | No       | `https://next.sonarqube.com/sonarqube` |
+| `skip_dry_run`       | Skip dry run and perform actual changes directly, recommended for use with startdate param which does a lot of queries      | No       | `false`                                |
+| `startdate`          | Start date for issue filtering (YYYY-MM-DD). Useful for batching issues requests when having more than the 10K issues limit | No       | ``                                     |
 
 ## Prerequisites
 

--- a/run-iris/action.yaml
+++ b/run-iris/action.yaml
@@ -40,6 +40,10 @@ inputs:
     description: Organization name
     required: false
     default: sonarsource
+  skip_dry_run:
+    description: Skip dry run and perform actual changes directly, recommended for use with startdate param which does a lot of queries
+    required: false
+    default: 'false'
   startdate:
     description: Start date for issue filtering (YYYY-MM-DD). Useful for batching issues requests when having more than the 10K issues limit.
     required: false
@@ -98,6 +102,7 @@ runs:
         SONAR_NEXT_URL: ${{ inputs.sonar_next_url }}
         SONAR_IRIS_NEXT_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).SONAR_IRIS_NEXT_TOKEN }}
         STARTDATE: ${{ inputs.startdate }}
+        SKIP_DRY_RUN: ${{ inputs.skip_dry_run }}
         ARTIFACTORY_USERNAME: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_USERNAME }}
         ARTIFACTORY_ACCESS_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }}
         ARTIFACTORY_URL: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_URL }}

--- a/run-iris/action.yaml
+++ b/run-iris/action.yaml
@@ -19,11 +19,11 @@ inputs:
     description: Platform of the first shadow platform (Next, SQC-EU, SQC-US)
     required: true
   shadow2_project_key:
-    description: Project key of the second shadow platform
-    required: true
+    description: Project key of the second shadow platform, iris run is skipped if not provided
+    required: false
   shadow2_platform:
-    description: Platform of the second shadow platform (Next, SQC-EU, SQC-US)
-    required: true
+    description: Platform of the second shadow platform (Next, SQC-EU, SQC-US), iris run is skipped if not provided
+    required: false
   sonar_sqc_eu_url:
     description: SonarCloud EU URL
     required: false

--- a/run-iris/run_iris.sh
+++ b/run-iris/run_iris.sh
@@ -147,23 +147,27 @@ else
   fi
 fi
 
-
-echo "===== Execute IRIS $PRIMARY_PLATFORM to $SHADOW2_PLATFORM as dry-run"
-if [ "$PRIMARY_PLATFORM" = "Next" ]; then
-  run_iris_next_to_sqc $SHADOW2_PROJECT_KEY $SHADOW2_PLATFORM "true"
+# Check if SHADOW2_PLATFORM is defined before running IRIS to SHADOW2
+if [ -z "${SHADOW2_PLATFORM:-}" ] || [ -z "${SHADOW2_PROJECT_KEY:-}" ]; then
+  echo "===== SHADOW2_PLATFORM or SHADOW2_PROJECT_KEY is not defined. Skipping IRIS execution to SHADOW2."
 else
-  run_iris_sqc_to_next_or_sqc $SHADOW2_PROJECT_KEY $SHADOW2_PLATFORM "true"
-fi
-STATUS=$?
-if [ $STATUS -ne 0 ]; then
-  echo "===== Failed to run IRIS dry-run"
-  exit 1
-else
-  echo "===== Successful IRIS Next dry-run - executing IRIS for real."
+  echo "===== Execute IRIS $PRIMARY_PLATFORM to $SHADOW2_PLATFORM as dry-run"
   if [ "$PRIMARY_PLATFORM" = "Next" ]; then
-    run_iris_next_to_sqc $SHADOW2_PROJECT_KEY $SHADOW2_PLATFORM "false"
+    run_iris_next_to_sqc $SHADOW2_PROJECT_KEY $SHADOW2_PLATFORM "true"
   else
-    run_iris_sqc_to_next_or_sqc $SHADOW2_PROJECT_KEY $SHADOW2_PLATFORM "false"
+    run_iris_sqc_to_next_or_sqc $SHADOW2_PROJECT_KEY $SHADOW2_PLATFORM "true"
+  fi
+  STATUS=$?
+  if [ $STATUS -ne 0 ]; then
+    echo "===== Failed to run IRIS dry-run"
+    exit 1
+  else
+    echo "===== Successful IRIS Next dry-run - executing IRIS for real."
+    if [ "$PRIMARY_PLATFORM" = "Next" ]; then
+      run_iris_next_to_sqc $SHADOW2_PROJECT_KEY $SHADOW2_PLATFORM "false"
+    else
+      run_iris_sqc_to_next_or_sqc $SHADOW2_PROJECT_KEY $SHADOW2_PLATFORM "false"
+    fi
   fi
 fi
 

--- a/run-iris/run_iris.sh
+++ b/run-iris/run_iris.sh
@@ -9,6 +9,7 @@ set -euo pipefail
 : "${SHADOW1_PROJECT_KEY?}" "${SHADOW1_PLATFORM?}"
 : "${SHADOW2_PROJECT_KEY?}" "${SHADOW2_PLATFORM?}"
 : "${ORGANIZATION?}"
+: "${SKIP_DRY_RUN?}"
 : "${STARTDATE?}"
 
 # Get dependency risk count
@@ -57,6 +58,11 @@ function run_iris_next_to_sqc () {
   local destination_token
   local startdate_param=$(get_startdate_param)
 
+  if [ "$SKIP_DRY_RUN" = "true" ] && [ "$dryrun" = "true" ]; then
+    echo "===== SKIP_DRY_RUN is true, skipping dry-run execution"
+    return 0
+  fi
+
   if [ "$destination_platform" = "SQC-EU" ]; then
     destination_url="$SONAR_SQC_EU_URL"
     destination_token="$SONAR_IRIS_SQC_EU_TOKEN"
@@ -86,6 +92,11 @@ function run_iris_sqc_to_next_or_sqc () {
   local destination_url
   local destination_token
   local startdate_param=$(get_startdate_param)
+
+  if [ "$SKIP_DRY_RUN" = "true" ] && [ "$dryrun" = "true" ]; then
+    echo "===== SKIP_DRY_RUN is true, skipping dry-run execution"
+    return 0
+  fi
 
   if [ "$destination_platform" = "Next" ]; then
     destination_url="$SONAR_NEXT_URL"


### PR DESCRIPTION
[SC-34602](https://sonarsource.atlassian.net/browse/SC-34602)
[SC-34607](https://sonarsource.atlassian.net/browse/SC-34607)

Here is the test run using this branch on sonarcloud-webapp repo: https://github.com/SonarSource/sonarcloud-webapp/actions/runs/18710379461/job/53357876990 


[SC-34602]: https://sonarsource.atlassian.net/browse/SC-34602?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[SC-34607]: https://sonarsource.atlassian.net/browse/SC-34607?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ