### PR TITLE
BUILD-9456 Take ownership of unified-dogfooding-actions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
-* @sonarsource/orchestration-storage-squad
+* @sonarsource/platform-eng-xp-squad

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
-Part of 
-<!-- 
-  Only for standalone PRs without Jira issue in the PR title: 
+# Part of
+<!--
+  Only for standalone PRs without Jira issue in the PR title:
     * Replace this comment with Epic ID to create a new Task in Jira
     * Replace this comment with Issue ID to create a new Sub-Task in Jira
-    * Ignore or delete this note to create a new Task in Jira without a parent 
+    * Ignore or delete this note to create a new Task in Jira without a parent
 -->

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": [
+        "github>SonarSource/renovate-config:dev-infra-squad"
+    ]
+}

--- a/.github/workflows/PullRequestClosed.yml
+++ b/.github/workflows/PullRequestClosed.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   PullRequestMerged_job:
     name: Pull Request Merged
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs-public
     permissions:
       id-token: write
       pull-requests: read

--- a/.github/workflows/PullRequestClosed.yml
+++ b/.github/workflows/PullRequestClosed.yml
@@ -13,8 +13,8 @@ jobs:
       pull-requests: read
     # For external PR, ticket should be moved manually
     if: |
-        github.event.pull_request.head.repo.full_name == github.repository
-        && github.event.pull_request.merged
+      github.event.pull_request.head.repo.full_name == github.repository
+      && github.event.pull_request.merged
     steps:
       - id: secrets
         uses: SonarSource/vault-action-wrapper@v3

--- a/.github/workflows/PullRequestCreated.yml
+++ b/.github/workflows/PullRequestCreated.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   PullRequestCreated_job:
     name: Pull Request Created
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs-public
     permissions:
       id-token: write
     # For external PR, ticket should be created manually

--- a/.github/workflows/PullRequestCreated.yml
+++ b/.github/workflows/PullRequestCreated.yml
@@ -12,7 +12,7 @@ jobs:
       id-token: write
     # For external PR, ticket should be created manually
     if: |
-        github.event.pull_request.head.repo.full_name == github.repository
+      github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - id: secrets
         uses: SonarSource/vault-action-wrapper@v3
@@ -26,4 +26,4 @@ jobs:
           github-token: ${{ fromJSON(steps.secrets.outputs.vault).GITHUB_TOKEN }}
           jira-user:    ${{ fromJSON(steps.secrets.outputs.vault).JIRA_USER }}
           jira-token:   ${{ fromJSON(steps.secrets.outputs.vault).JIRA_TOKEN }}
-          jira-project: SC
+          jira-project: BUILD

--- a/.github/workflows/RequestReview.yml
+++ b/.github/workflows/RequestReview.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   RequestReview_job:
     name: Request review
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs-public
     permissions:
       id-token: write
     # For external PR, ticket should be moved manually

--- a/.github/workflows/SubmitReview.yml
+++ b/.github/workflows/SubmitReview.yml
@@ -13,9 +13,9 @@ jobs:
       pull-requests: read
     # For external PR, ticket should be moved manually
     if: |
-        github.event.pull_request.head.repo.full_name == github.repository
-        && (github.event.review.state == 'changes_requested'
-            || github.event.review.state == 'approved')
+      github.event.pull_request.head.repo.full_name == github.repository
+      && (github.event.review.state == 'changes_requested'
+          || github.event.review.state == 'approved')
     steps:
       - id: secrets
         uses: SonarSource/vault-action-wrapper@v3

--- a/.github/workflows/SubmitReview.yml
+++ b/.github/workflows/SubmitReview.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   SubmitReview_job:
     name: Submit Review
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs-public
     permissions:
       id-token: write
       pull-requests: read

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,39 @@
+---
+
+name: Build
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+    inputs:
+      skip_dry_run:
+        description: "Skip dry-run and run IRIS directly (use with caution)"
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  # The pre-commit job runs YAML linting and other hooks on pull requests.
+  # It is defined in pre-commit.yml and runs automatically on every PR.
+
+  test-run-iris:
+    name: Test run-iris action
+    runs-on: sonar-xs-public
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Run IRIS Analysis (local action)
+        uses: ./run-iris
+        with:
+          primary_project_key: "org.sonarsource.java:java"
+          primary_platform: "Next"
+          shadow1_project_key: "org.sonarsource.java:java"
+          shadow1_platform: "SQC-EU"
+          shadow2_project_key: "org.sonarsource.java:java"
+          shadow2_platform: "SQC-US"
+          skip_dry_run: ${{ inputs.skip_dry_run || 'false' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@
 name: Build
 
 on:
+  pull_request:
   push:
     branches:
       - master
@@ -15,11 +16,8 @@ on:
         default: false
 
 jobs:
-  # The pre-commit job runs YAML linting and other hooks on pull requests.
-  # It is defined in pre-commit.yml and runs automatically on every PR.
-
-  test-run-iris:
-    name: Test run-iris action
+  run-iris:
+    name: Run IRIS Analysis
     runs-on: sonar-xs-public
     permissions:
       id-token: write
@@ -30,10 +28,9 @@ jobs:
       - name: Run IRIS Analysis (local action)
         uses: ./run-iris
         with:
-          primary_project_key: "org.sonarsource.java:java"
-          primary_platform: "Next"
-          shadow1_project_key: "org.sonarsource.java:java"
-          shadow1_platform: "SQC-EU"
-          shadow2_project_key: "org.sonarsource.java:java"
+          primary_project_key: "SonarSource_sonar-dummy"
+          primary_platform: "SQC-EU"
+          shadow1_project_key: "SonarSource_sonar-dummy"
+          shadow1_platform: "Next"
+          shadow2_project_key: "SonarSource_sonar-dummy"
           shadow2_platform: "SQC-US"
-          skip_dry_run: ${{ inputs.skip_dry_run || 'false' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,13 +7,6 @@ on:
   push:
     branches:
       - master
-  workflow_dispatch:
-    inputs:
-      skip_dry_run:
-        description: "Skip dry-run and run IRIS directly (use with caution)"
-        required: false
-        type: boolean
-        default: false
 
 jobs:
   run-iris:
@@ -28,9 +21,9 @@ jobs:
       - name: Run IRIS Analysis (local action)
         uses: ./run-iris
         with:
-          primary_project_key: "SonarSource_sonar-dummy"
+          primary_project_key: "SonarSource_unified-dogfooding-actions"
           primary_platform: "SQC-EU"
-          shadow1_project_key: "SonarSource_sonar-dummy"
+          shadow1_project_key: "SonarSource_unified-dogfooding-actions"
           shadow1_platform: "Next"
-          shadow2_project_key: "SonarSource_sonar-dummy"
+          shadow2_project_key: "SonarSource_unified-dogfooding-actions"
           shadow2_platform: "SQC-US"

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   pre-commit:
     name: "pre-commit"
-    runs-on: ubuntu-latest
+    runs-on: sonar-xs-public
     steps:
       - uses: SonarSource/gh-action_pre-commit@fc9d73025994fd1c2b96d568c8c8a4af82a3ae21 # 1.0.6
         with:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -7,8 +7,12 @@ jobs:
   pre-commit:
     name: "pre-commit"
     runs-on: sonar-xs-public
+    permissions:
+      id-token: write
+      contents: write
     steps:
-      - uses: SonarSource/gh-action_pre-commit@fc9d73025994fd1c2b96d568c8c8a4af82a3ae21 # 1.0.6
+      - uses: SonarSource/ci-github-actions/config-npm@v1
+      - uses: SonarSource/gh-action_pre-commit@2ddc0c7fdabce0adfaaa4075a17690972ed9961a # 1.2.0
         with:
           extra-args: >
             --from-ref=origin/${{ github.event.pull_request.base.ref }}

--- a/README.md
+++ b/README.md
@@ -27,3 +27,7 @@ Hooks run automatically on every commit. To run them manually:
 ```sh
 pre-commit run --all-files
 ```
+
+## Release
+
+See [release](https://github.com/SonarSource/ci-github-actions/#release).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # unified-dogfooding-actions
 
-Reusable GitHub Actions for [Unified Platform Dogfooding](https://docs.google.com/document/d/1uYRuki3lQEfhbUbqHXXsyXZZViYVk5lSSuxXk22uz3g/) at SonarSource.
+Reusable GitHub Actions for [Unified Platform Dogfooding](https://docs.google.com/document/d/1uYRuki3lQEfhbUbqHXXsyXZZViYVk5lSSuxXk22uz3g/)
+at SonarSource.
 
 Maintained by the **Platform Engineering Experience squad** (`@sonarsource/platform-eng-xp-squad`).
 
@@ -8,7 +9,8 @@ Maintained by the **Platform Engineering Experience squad** (`@sonarsource/platf
 
 ### [`run-iris`](./run-iris/README.md)
 
-Runs the [IRIS](https://github.com/SonarSource/iris) analysis tool to synchronize issues between SonarQube instances (Next, SQC-EU, SQC-US). See the [run-iris README](./run-iris/README.md) for usage details and examples.
+Runs the [IRIS](https://github.com/SonarSource/iris) analysis tool to synchronize issues between SonarQube instances (Next, SQC-EU, SQC-US).
+See the [run-iris README](./run-iris/README.md) for usage details and examples.
 
 ## Development
 
@@ -25,7 +27,3 @@ Hooks run automatically on every commit. To run them manually:
 ```sh
 pre-commit run --all-files
 ```
-
-### Releasing
-
-See [RELEASING.md](./RELEASING.md) for instructions on how to release a new version and update the `v*` branches.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,31 @@
 # unified-dogfooding-actions
 
-Github actions used for Unified dogfooding
+Reusable GitHub Actions for [Unified Platform Dogfooding](https://docs.google.com/document/d/1uYRuki3lQEfhbUbqHXXsyXZZViYVk5lSSuxXk22uz3g/) at SonarSource.
+
+Maintained by the **Platform Engineering Experience squad** (`@sonarsource/platform-eng-xp-squad`).
+
+## Actions
+
+### [`run-iris`](./run-iris/README.md)
+
+Runs the [IRIS](https://github.com/SonarSource/iris) analysis tool to synchronize issues between SonarQube instances (Next, SQC-EU, SQC-US). See the [run-iris README](./run-iris/README.md) for usage details and examples.
+
+## Development
+
+### Pre-commit
+
+This repository uses [pre-commit](https://pre-commit.com/) to enforce code quality checks. Install it and run:
+
+```sh
+pre-commit install
+```
+
+Hooks run automatically on every commit. To run them manually:
+
+```sh
+pre-commit run --all-files
+```
+
+### Releasing
+
+See [RELEASING.md](./RELEASING.md) for instructions on how to release a new version and update the `v*` branches.

--- a/run-iris/action.yaml
+++ b/run-iris/action.yaml
@@ -54,7 +54,7 @@ runs:
   steps:
     - name: Mise setup
       id: mise-setup
-      uses: jdx/mise-action@13abe502c30c1559a5c37dff303831bab82c9402 # v2.2.3
+      uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
       with:
         cache_save: true
         cache_key_prefix: mise-v1
@@ -72,7 +72,7 @@ runs:
 
     - name: Get secrets from Vault
       id: secrets
-      uses: SonarSource/vault-action-wrapper@eeb41b89722805725f07028c393860a50c60b51d
+      uses: SonarSource/vault-action-wrapper@c154b4a417b51cb98dd71137f49bf20e77c56820 # v3.4.0
       with:
         secrets: |
           development/kv/data/iris next | SONAR_IRIS_NEXT_TOKEN;


### PR DESCRIPTION
BUILD-9456

## What

Takes ownership of this repository from `orchestration-storage-squad` and brings it in line with Engineering Experience squad standards.

## Changes

**Ownership**
- `CODEOWNERS` – transferred to `@sonarsource/platform-eng-xp-squad`

**Workflows**
- All runners migrated from `github-ubuntu-latest-s` / `ubuntu-latest` to `sonar-xs-public`
- `PullRequestCreated` – Jira project changed from `SC` to `BUILD`
- `build.yml` (new) – CI workflow that tests the `run-iris` action end-to-end using `./run-iris` (local path); triggers on `pull_request`, `push` to `master`, and `workflow_dispatch` with an optional `skip_dry_run` input

**Documentation**
- `README.md` – rewritten with proper description, pre-commit setup instructions, and a link to RELEASING.md
- `RELEASING.md` (new) – documents the `v*` floating branch strategy, how to push a release, and when to cut a new major version

**Dependencies** (bumped by pre-commit hooks)
- `jdx/mise-action`: v2.2.3 → v4.0.1
- `SonarSource/vault-action-wrapper`: pinned to v3.4.0 with commit hash

## Not included (manual steps remaining)

- Update GitHub team collaborators: add `platform-eng-xp-squad`, remove `orchestration-storage-squad` / `orchestration-elevated-team` (requires org admin access)
- Add to Xtranet repositories list