### PR TITLE
BUILD-11519 Migrate run-iris Slack notification to slack-github-action v3

### DIFF
--- a/run-iris/action.yaml
+++ b/run-iris/action.yaml
@@ -109,9 +109,10 @@ runs:
 
     - name: Notify Slack of Open Issues
       if: steps.run-iris.outputs.total-count != '0'
-      uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0
-      env:
-        SLACK_BOT_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).SLACK_BOT_TOKEN }}
+      uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
       with:
-        channel-id: alerts-ist-sca
-        slack-message: "IRIS has detected open issues in one or more shadow platforms. Please review the issues and resolve them."
+        method: chat.postMessage
+        token: ${{ fromJSON(steps.secrets.outputs.vault).SLACK_BOT_TOKEN }}
+        payload: |
+          channel: "alerts-ist-sca"
+          text: "IRIS has detected open issues in one or more shadow platforms. Please review the issues and resolve them."


### PR DESCRIPTION
## Why

`run-iris/action.yaml` pinned `slackapi/slack-github-action@v1.26.0`, which runs on **Node 20**. GitHub is deprecating Node 20 on Actions runners (enforcement **2026-06-02**, full removal Fall 2026). The Node 24 target is `slack-github-action@v3`.

This was surfaced during the [BUILD-10781](https://sonarsource.atlassian.net/browse/BUILD-10781) cascade audit and tracked under [BUILD-11519](https://sonarsource.atlassian.net/browse/BUILD-11519). The sibling migration in `gh-action_release` is [BUILD-11518](https://sonarsource.atlassian.net/browse/BUILD-11518).

## What changed

`v1` → `v3` is **not a drop-in pin bump** — the convenience inputs were removed in v2. Migrated the "Notify Slack of Open Issues" step to the v3 input model:

| | Before (v1.26.0) | After (v3.0.3) |
|---|---|---|
| token | `SLACK_BOT_TOKEN` **env** | `token` **input** |
| channel | `channel-id: alerts-ist-sca` | `payload.channel: "alerts-ist-sca"` |
| message | `slack-message: "…"` | `payload.text: "…"` |
| method | implicit (`chat.postMessage`) | `method: chat.postMessage` |

- Channel (`alerts-ist-sca`) and message text are **preserved unchanged**.
- Pinned by **SHA** (`45a88b9…` = v3.0.3) per repo convention.
- Same `if:` gate (`steps.run-iris.outputs.total-count != '0'`) and same Vault `SLACK_BOT_TOKEN` secret.

## Acceptance criteria ([BUILD-11519](https://sonarsource.atlassian.net/browse/BUILD-11519))

- [x] `run-iris/action.yaml` updated to `slack-github-action@v3.x` with `method` + `token` + `payload`
- [x] Pinned by SHA
- [ ] Smoke test that the Slack post still lands in `#alerts-ist-sca` with the expected text (see Test plan)

## Test plan

The repo's own `Build` workflow runs `./run-iris` against `SonarSource_unified-dogfooding-actions` across Next/SQC-EU/SQC-US on every PR, so this PR exercises the action. The Slack step only fires when IRIS finds open issues (`total-count != '0'`).

To positively confirm the Slack post under v3:

1. Temporarily force the notify step to run by setting `if: always()` on a throwaway commit on this branch (or wire a `workflow_dispatch` that points a consumer at `run-iris@feat/smarini/BUILD-11519-slackV3`).
2. Trigger the workflow and confirm a message lands in **`#alerts-ist-sca`** with the expected text.
3. Confirm the step logs show **no Node 20 deprecation warning** and resolve `slack-github-action` to v3.0.3.
4. Revert the temporary `if: always()` before merge.

Alternatively, run a controlled dogfooding dispatch from a consumer repo (e.g. `sonar-java`, `sonar-dummy`) against this branch.

[BUILD-10781]: https://sonarsource.atlassian.net/browse/BUILD-10781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BUILD-11519]: https://sonarsource.atlassian.net/browse/BUILD-11519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BUILD-11518]: https://sonarsource.atlassian.net/browse/BUILD-11518?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BUILD-11519]: https://sonarsource.atlassian.net/browse/BUILD-11519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ